### PR TITLE
Fixed version of module EKS

### DIFF
--- a/demo-terraform-eks-cluster/eks-cluster.tf
+++ b/demo-terraform-eks-cluster/eks-cluster.tf
@@ -2,6 +2,13 @@ module "eks" {
   source          = "terraform-aws-modules/eks/aws"
   cluster_name    = local.cluster_name
   cluster_version = "1.20"
+  
+  # this ensures that we can still use the properties
+  # `subnets`, `worker_groups_defaults` and `worker_groups`
+  # that since version 18.0.0 are no longer supported.
+  #
+  version	  = "17.24.0"
+  
   subnets         = module.vpc.private_subnets
 
   tags = {


### PR DESCRIPTION
The latest version of the EKS modules (i.e. 18+) has introduced breaking changes to some of the properties definitions of the EKS module. Namely: `subnets`, `worker_groups` and `worker_group_defaults`are no longer recognised.

Constraining the version to the latest available 17.24.0 that supports the current definition will do.
An alternative, is to update the definition of the cluster to the latest syntax. 